### PR TITLE
fix: remove deprecated import

### DIFF
--- a/schoolyourself/schoolyourself_lesson.py
+++ b/schoolyourself/schoolyourself_lesson.py
@@ -3,7 +3,11 @@
 import six.moves.urllib.request, six.moves.urllib.parse, six.moves.urllib.error
 
 from xblock.core import XBlock
-from xblock.fragment import Fragment
+try:
+    from web_fragments.fragment import Fragment
+except:
+    # for backwards compatibility with quince and prior releases
+    from xblock.fragment import Fragment
 
 from .schoolyourself import SchoolYourselfXBlock
 

--- a/schoolyourself/schoolyourself_review.py
+++ b/schoolyourself/schoolyourself_review.py
@@ -7,7 +7,11 @@ import six.moves.urllib.request, six.moves.urllib.parse, six.moves.urllib.error
 
 from xblock.core import XBlock
 from xblock.fields import Scope, String
-from xblock.fragment import Fragment
+try:
+    from web_fragments.fragment import Fragment
+except:
+    # for backwards compatibility with quince and prior releases
+    from xblock.fragment import Fragment
 
 from .schoolyourself import SchoolYourselfXBlock
 

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ def package_data(pkg, roots):
 
 setup(
   name="schoolyourself-xblock",
-  version="0.2",
+  version="0.2.1",
   description="School Yourself lesson player",
   packages=[
     "schoolyourself",


### PR DESCRIPTION
## Description
This replace `xblock.fragment` with `web_fragments.fragment`. `xblock.fragment` was [removed as of 2024-02-26](https://docs.openedx.org/projects/xblock/en/latest/changelog.html#id2). If this xblock is used in a course, the entire course will fail to load.
